### PR TITLE
Generalize url in editbox-currentpage

### DIFF
--- a/JWB.js
+++ b/JWB.js
@@ -387,6 +387,7 @@ JWB.api.get = function(pagename) {
 		if (response.query.redirects) {
 			JWB.page.name = response.query.redirects[0].to;
 		}
+		JWB.page.path = mw.config.get('wgArticlePath').replace('$1', JWB.page.name);
 		// check for skips that can be determined before replacing
 		if (!JWB.fn.allowBots(JWB.page.content, JWB.username) || !JWB.fn.allowBots(JWB.page.content)) {
 			// skip if {{bots}} template forbids editing on this page by user OR by JWB in general
@@ -1278,7 +1279,7 @@ JWB.replace = function(input, callback) {
 // Edit the current page and pre-fill the newContent.
 JWB.editPage = function(newContent) {
 	$('#editBoxArea').val(newContent);
-	$('#currentpage').html(JWB.msg('editbox-currentpage', JWB.page.name, encodeURIComponent(JWB.page.name)));
+	$('#currentpage').html(JWB.msg('editbox-currentpage', JWB.page.path, encodeURIComponent(JWB.page.name)));
 	if ($('#preparse').prop('checked')) {
 		$('#articleList').val($.trim($('#articleList').val()) + '\n' + JWB.list[0]); //move current page to the bottom
 		JWB.next();

--- a/i18n.js
+++ b/i18n.js
@@ -52,7 +52,7 @@ JWB.messages.en = {
 	'tab-log':				'Log',
 	'pagelist-caption':		'Enter list of pages:',
 	'editbox-caption':		'Editing area',
-	'editbox-currentpage':	'You are editing: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'You are editing: <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made':		'No changes made. Press skip to go to the next page in the list.',
 	'page-not-exists':		'Page doesn\'t exist, diff can not be made.',
 	

--- a/i18n/be.js
+++ b/i18n/be.js
@@ -16,7 +16,7 @@ JWB.messages.be = {
 	'tab-log':				'Часопіс',
 	'pagelist-caption':		'Пакажыце назвы старонак:',
 	'editbox-caption':		'Вобласць рэдагавання',
-	'editbox-currentpage':	'Вы рэдагуеце: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Вы рэдагуеце: <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made':		'Змен няма. Націсніце кнопку «Прапусціць», каб перайсці да наступнай старонкі ў спісе.',
 	'page-not-exists':		'Старонка не існуе, прагляд змены не можа быць створаны.',
  

--- a/i18n/fa.js
+++ b/i18n/fa.js
@@ -17,7 +17,7 @@ JWB.messages.fa = {
 	'tab-log':				'سیاهه',
 	'pagelist-caption':		'فهرستی از صفحه‌ها وارد کنید:',
 	'editbox-caption':		'جعبه ویرایش',
-	'editbox-currentpage':	'شما در حال ویرایش <a href="/wiki/$2" target="_blank" title="$1">$1</a> هستید:',
+	'editbox-currentpage':	'شما در حال ویرایش <a href="$2" target="_blank" title="$1">$1</a> هستید:',
 	'no-changes-made':		'هیچ تغییری داده نشد.  دکمهٔ «رد کردن» را بزنید تا به صفحهٔ بعدی در فهرست بروید.',
 	'page-not-exists':		'صفحه وجود ندارد، تفاوت را نمی‌توان ساخت.',
 	

--- a/i18n/gl.js
+++ b/i18n/gl.js
@@ -17,7 +17,7 @@ JWB.messages.gl = {
 	'tab-log':				'Rexistro',
 	'pagelist-caption':		'Indicar lista de páxinas:',
 	'editbox-caption':		'Área de edición',
-	'editbox-currentpage':	'Está a editar: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Está a editar: <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made':		'Non se fixeron cambios. Prema Saltar para pasar á seguinte páxina da lista.',
 	'page-not-exists':		'A páxina non existe, non se poden xerar as diferenzas.',
 	

--- a/i18n/he.js
+++ b/i18n/he.js
@@ -16,7 +16,7 @@ JWB.messages.he = {
 	'tab-log':				'יומן',
 	'pagelist-caption':		'הכנס רשימת דפים:',
 	'editbox-caption':		'אזור עריכה',
-	'editbox-currentpage':	'אתה עורך את: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'אתה עורך את: <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made':		'לא בוצעו שינויים. לחץ על כפתור "דלג" כדי לעבור לדף הבא.',
 	'page-not-exists':		'הדף לא קיים.',
 	

--- a/i18n/it.js
+++ b/i18n/it.js
@@ -17,7 +17,7 @@ JWB.messages.it = {
 	'tab-log':				'Log',
 	'pagelist-caption':		'Lista di pagine:',
 	'editbox-caption':		'Area di modifica',
-	'editbox-currentpage':	'Modifica di <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Modifica di <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made':		'Nessuna modifica effettuata. Premere salta per andare alla pagina seguente della lista.',
 	'page-not-exists':		'Pagina non esistente, non è possibile effettuare il confronto.',
 	

--- a/i18n/nl.js
+++ b/i18n/nl.js
@@ -17,7 +17,7 @@ JWB.messages.nl = {
 	'tab-log':				'Log',
 	'pagelist-caption':		'Lijst met pagina\'s:',
 	'editbox-caption':		'Bewerkingsveld',
-	'editbox-currentpage':	'Je bewerkt nu: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Je bewerkt nu: <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made':		'Geen bewerkingen gemaakt. Druk op skip om door te gaan met de volgende pagina in de lijst.',
 	'page-not-exists':		'Pagina bestaat niet. Wijzigingen kunnen niet worden opgesteld.',
 	

--- a/i18n/ru.js
+++ b/i18n/ru.js
@@ -16,7 +16,7 @@ JWB.messages.ru = {
 	'tab-log':				'Журнал',
 	'pagelist-caption':		'Укажите названия страниц:',
 	'editbox-caption':		'Область редактирования',
-	'editbox-currentpage':	'Вы редактируете: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Вы редактируете: <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made':		'Изменений нет. Нажмите кнопку «Пропустить», чтобы перейти к следующей странице в списке.',
 	'page-not-exists':		'Страница не существует, просмотр изменения не может быть создан.',
  

--- a/i18n/uk.js
+++ b/i18n/uk.js
@@ -16,7 +16,7 @@ JWB.messages.uk = {
 	'tab-log':				'Журнал',
 	'pagelist-caption':		'Вкажіть назви сторінок:',
 	'editbox-caption':		'Область редактирования',
-	'editbox-currentpage':	'Ви редагуєте: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Ви редагуєте: <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made':		'Змін немає. Натисніть кнопку «Пропустити», щоб перейти до наступної сторінки в списку.',
 	'page-not-exists':		'Сторінка не існує, перегляд зміни не може бути створено.',
  

--- a/i18n/zh_hans.js
+++ b/i18n/zh_hans.js
@@ -17,7 +17,7 @@ JWB.messages.zh_hans = {
 	'tab-log': '日志',
 	'pagelist-caption': '在下方输入页面列表:',
 	'editbox-caption': '编辑区域',
-	'editbox-currentpage': '正在编辑: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage': '正在编辑: <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made': '没有可应用更改。按“跳过”转至列表中的下一项。',
 	'page-not-exists': '页面不存在，无法展示差异。',
 

--- a/i18n/zh_hant.js
+++ b/i18n/zh_hant.js
@@ -17,7 +17,7 @@ JWB.messages.zh_hant = {
 	'tab-log': '日誌',
 	'pagelist-caption': '在下方輸入頁面列表:',
 	'editbox-caption': '編輯區域',
-	'editbox-currentpage': '正在編輯: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage': '正在編輯: <a href="$2" target="_blank" title="$1">$1</a>',
 	'no-changes-made': '沒有可應用更改。按「跳過」轉至列表中的下一項。',
 	'page-not-exists': '頁面不存在，無法展示差異。',
 


### PR DESCRIPTION
Some wikis have complex wgArticlePath and /wiki/${wgPageName} is not valid for that wikis, for instance, a wiki using a other language than English on Fandom.org.