### PR TITLE
Add accesskey to more UI contols

### DIFF
--- a/JWB.js
+++ b/JWB.js
@@ -1866,7 +1866,7 @@ JWB.init = function() {
 		'</fieldset>'
 	);
 	$('.JWBtabc[data-tab="2"]').html(
-		'<label class="minorEdit"><input type="checkbox" id="minorEdit" checked> '+JWB.msg('minor-edit')+'</label>'+
+		'<label class="minorEdit"><input type="checkbox" id="minorEdit" accesskey="i" checked> '+JWB.msg('minor-edit')+'</label>'+
 		'<label class="editSummary viaJWB">'+JWB.msg('edit-summary')+'<br/> <input class="fullwidth" type="text" id="summary" maxlength="500"></label>'+
 		' <input type="checkbox" id="viaJWB" checked title="'+JWB.msg('tip-via-JWB')+'">'+
 		'<select id="watchPage">'+

--- a/JWB.js
+++ b/JWB.js
@@ -1788,7 +1788,7 @@ JWB.init = function() {
 				'</section>'+
 				'<aside id="editBox">'+
 					'<b>'+JWB.msg('editbox-caption')+' - <span id="currentpage">'+JWB.msg('editbox-currentpage', ' ', ' ')+'</span></b>'+
-					'<textarea id="editBoxArea"></textarea>'+
+					'<textarea id="editBoxArea" accesskey=","></textarea>'+
 				'</aside>'+
 			'</div>'+
 		'</main>'+

--- a/JWB.js
+++ b/JWB.js
@@ -1867,7 +1867,7 @@ JWB.init = function() {
 	);
 	$('.JWBtabc[data-tab="2"]').html(
 		'<label class="minorEdit"><input type="checkbox" id="minorEdit" accesskey="i" checked> '+JWB.msg('minor-edit')+'</label>'+
-		'<label class="editSummary viaJWB">'+JWB.msg('edit-summary')+'<br/> <input class="fullwidth" type="text" id="summary" maxlength="500"></label>'+
+		'<label class="editSummary viaJWB">'+JWB.msg('edit-summary')+'<br/> <input class="fullwidth" type="text" id="summary" maxlength="500" accesskey="b"></label>'+
 		' <input type="checkbox" id="viaJWB" checked title="'+JWB.msg('tip-via-JWB')+'">'+
 		'<select id="watchPage">'+
 			'<option value="watch">'+JWB.msg('watch-watch')+'</option>'+

--- a/i18n.js
+++ b/i18n.js
@@ -52,7 +52,7 @@ JWB.messages.en = {
 	'tab-log':				'Log',
 	'pagelist-caption':		'Enter list of pages:',
 	'editbox-caption':		'Editing area',
-	'editbox-currentpage':	'You are editing: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'You are editing: <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made':		'No changes made. Press skip to go to the next page in the list.',
 	'page-not-exists':		'Page doesn\'t exist, diff can not be made.',
 	

--- a/i18n/be.js
+++ b/i18n/be.js
@@ -16,7 +16,7 @@ JWB.messages.be = {
 	'tab-log':				'Часопіс',
 	'pagelist-caption':		'Пакажыце назвы старонак:',
 	'editbox-caption':		'Вобласць рэдагавання',
-	'editbox-currentpage':	'Вы рэдагуеце: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Вы рэдагуеце: <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made':		'Змен няма. Націсніце кнопку «Прапусціць», каб перайсці да наступнай старонкі ў спісе.',
 	'page-not-exists':		'Старонка не існуе, прагляд змены не можа быць створаны.',
  

--- a/i18n/fa.js
+++ b/i18n/fa.js
@@ -17,7 +17,7 @@ JWB.messages.fa = {
 	'tab-log':				'سیاهه',
 	'pagelist-caption':		'فهرستی از صفحه‌ها وارد کنید:',
 	'editbox-caption':		'جعبه ویرایش',
-	'editbox-currentpage':	'شما در حال ویرایش <a href="/wiki/$2" target="_blank" title="$1">$1</a> هستید:',
+	'editbox-currentpage':	'شما در حال ویرایش <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a> هستید:',
 	'no-changes-made':		'هیچ تغییری داده نشد.  دکمهٔ «رد کردن» را بزنید تا به صفحهٔ بعدی در فهرست بروید.',
 	'page-not-exists':		'صفحه وجود ندارد، تفاوت را نمی‌توان ساخت.',
 	

--- a/i18n/gl.js
+++ b/i18n/gl.js
@@ -17,7 +17,7 @@ JWB.messages.gl = {
 	'tab-log':				'Rexistro',
 	'pagelist-caption':		'Indicar lista de páxinas:',
 	'editbox-caption':		'Área de edición',
-	'editbox-currentpage':	'Está a editar: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Está a editar: <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made':		'Non se fixeron cambios. Prema Saltar para pasar á seguinte páxina da lista.',
 	'page-not-exists':		'A páxina non existe, non se poden xerar as diferenzas.',
 	

--- a/i18n/he.js
+++ b/i18n/he.js
@@ -16,7 +16,7 @@ JWB.messages.he = {
 	'tab-log':				'יומן',
 	'pagelist-caption':		'הכנס רשימת דפים:',
 	'editbox-caption':		'אזור עריכה',
-	'editbox-currentpage':	'אתה עורך את: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'אתה עורך את: <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made':		'לא בוצעו שינויים. לחץ על כפתור "דלג" כדי לעבור לדף הבא.',
 	'page-not-exists':		'הדף לא קיים.',
 	

--- a/i18n/it.js
+++ b/i18n/it.js
@@ -17,7 +17,7 @@ JWB.messages.it = {
 	'tab-log':				'Log',
 	'pagelist-caption':		'Lista di pagine:',
 	'editbox-caption':		'Area di modifica',
-	'editbox-currentpage':	'Modifica di <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Modifica di <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made':		'Nessuna modifica effettuata. Premere salta per andare alla pagina seguente della lista.',
 	'page-not-exists':		'Pagina non esistente, non è possibile effettuare il confronto.',
 	

--- a/i18n/nl.js
+++ b/i18n/nl.js
@@ -17,7 +17,7 @@ JWB.messages.nl = {
 	'tab-log':				'Log',
 	'pagelist-caption':		'Lijst met pagina\'s:',
 	'editbox-caption':		'Bewerkingsveld',
-	'editbox-currentpage':	'Je bewerkt nu: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Je bewerkt nu: <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made':		'Geen bewerkingen gemaakt. Druk op skip om door te gaan met de volgende pagina in de lijst.',
 	'page-not-exists':		'Pagina bestaat niet. Wijzigingen kunnen niet worden opgesteld.',
 	

--- a/i18n/ru.js
+++ b/i18n/ru.js
@@ -16,7 +16,7 @@ JWB.messages.ru = {
 	'tab-log':				'Журнал',
 	'pagelist-caption':		'Укажите названия страниц:',
 	'editbox-caption':		'Область редактирования',
-	'editbox-currentpage':	'Вы редактируете: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Вы редактируете: <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made':		'Изменений нет. Нажмите кнопку «Пропустить», чтобы перейти к следующей странице в списке.',
 	'page-not-exists':		'Страница не существует, просмотр изменения не может быть создан.',
  

--- a/i18n/uk.js
+++ b/i18n/uk.js
@@ -16,7 +16,7 @@ JWB.messages.uk = {
 	'tab-log':				'Журнал',
 	'pagelist-caption':		'Вкажіть назви сторінок:',
 	'editbox-caption':		'Область редактирования',
-	'editbox-currentpage':	'Ви редагуєте: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage':	'Ви редагуєте: <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made':		'Змін немає. Натисніть кнопку «Пропустити», щоб перейти до наступної сторінки в списку.',
 	'page-not-exists':		'Сторінка не існує, перегляд зміни не може бути створено.',
  

--- a/i18n/zh_hans.js
+++ b/i18n/zh_hans.js
@@ -17,7 +17,7 @@ JWB.messages.zh_hans = {
 	'tab-log': '日志',
 	'pagelist-caption': '在下方输入页面列表:',
 	'editbox-caption': '编辑区域',
-	'editbox-currentpage': '正在编辑: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage': '正在编辑: <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made': '没有可应用更改。按“跳过”转至列表中的下一项。',
 	'page-not-exists': '页面不存在，无法展示差异。',
 

--- a/i18n/zh_hant.js
+++ b/i18n/zh_hant.js
@@ -17,7 +17,7 @@ JWB.messages.zh_hant = {
 	'tab-log': '日誌',
 	'pagelist-caption': '在下方輸入頁面列表:',
 	'editbox-caption': '編輯區域',
-	'editbox-currentpage': '正在編輯: <a href="/wiki/$2" target="_blank" title="$1">$1</a>',
+	'editbox-currentpage': '正在編輯: <a href="/wiki/$2" target="_blank" title="$1" accesskey="c">$1</a>',
 	'no-changes-made': '沒有可應用更改。按「跳過」轉至列表中的下一項。',
 	'page-not-exists': '頁面不存在，無法展示差異。',
 


### PR DESCRIPTION
### Context

MediaWiki's interface has many UI elements that have [`accesskey` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey), which helps control and navigate the UI faster via [keyboard shortcuts](https://en.wikipedia.org/wiki/Wikipedia:Keyboard_shortcuts).

JWB, very helpfully, reproduces some of these accesskeys, but not all of them. Some aren't relevant in JWB's UI, like <kbd>x</kbd> for "Random article", but some of them would be helpful.

### Change

This pull request adds `accesskey` attribute to the UI elements of JWB, where it makes sense.

### accesskey values

All added `accesskey`s mirror the [shortcuts of MediaWiki](https://en.wikipedia.org/wiki/Wikipedia:Keyboard_shortcuts). I've checked languages currently supported by JWB to make sure that `accesskey`s aren't overridden on other language editions of Wikipedia, using a simple Bash script:

```sh
#!/bin/bash

# array of message IDs per https://www.mediawiki.org/wiki/Manual:Access_keys#MediaWiki_core
# Only the message IDs, which we are adding in this PR
declare -a messages=( "Accesskey-minoredit" "Accesskey-summary" "Accesskey-ca-nstab" "Accesskey-ca-nstab-main" )

# array of language codes per directory i18n/
declare -a languages=( he fa en be gl it nl ru uk zh )

for message in "${messages[@]}"
do
        for language in "${languages[@]}"
        do
                # example: https://it.wikipedia.org/wiki/MediaWiki:Accesskey-watch
                url="https://${language}.wikipedia.org/wiki/MediaWiki:${message}"
                echo "$language + $message = $url"
                curl --silent "${url}" | grep mw-content-text
        done
done
```

Hebrew and Farsi Wikipedias had to be checked manually, because the prefix "MediaWiki" is localized there.

1. Localization for hewiki <https://github.com/wikimedia/operations-mediawiki-config/blob/585a8c4e12c41e9d5ea88afde337569bcc0ba280/wmf-config/core-Namespaces.php#L620-L621>
2. Couldn't find where fawiki is localized though. Example page: <https://fa.wikipedia.org/wiki/%D9%85%D8%AF%DB%8C%D8%A7%D9%88%DB%8C%DA%A9%DB%8C:Accesskey-summary>

One of the `accesskey`s isn't i18n'ed. `accesskey=","` for the editbox is hardcoded: <https://github.com/wikimedia/mediawiki/blob/wmf/1.41.0-wmf.29/includes/editpage/TextboxBuilder.php#L107>

